### PR TITLE
Sort toc

### DIFF
--- a/src/toc/mod.rs
+++ b/src/toc/mod.rs
@@ -18,13 +18,19 @@ pub struct Toc {
 
 impl Default for Toc {
     fn default() -> Self {
-        Self { entries: Vec::default(), is_sorted_by_name: true }
+        Self {
+            entries: Vec::default(),
+            is_sorted_by_name: true,
+        }
     }
 }
 
 impl Toc {
     pub(crate) fn with_capacity(capacity: usize) -> Self {
-        Self { entries: Vec::with_capacity(capacity), is_sorted_by_name: true }
+        Self {
+            entries: Vec::with_capacity(capacity),
+            is_sorted_by_name: true,
+        }
     }
 
     /// Find a section by name.
@@ -44,7 +50,13 @@ impl Toc {
     /// tracking whether or not the table is/ remains sorted.
     pub(crate) fn push(&mut self, entry: TocEntry) {
         let empty: [u8; 0] = [];
-        if self.is_sorted_by_name && self.entries.last().map_or(empty.as_slice(), |e: &TocEntry| e.name()) > entry.name() {
+        if self.is_sorted_by_name
+            && self
+                .entries
+                .last()
+                .map_or(empty.as_slice(), |e: &TocEntry| e.name())
+                > entry.name()
+        {
             self.is_sorted_by_name = false;
         }
         self.entries.push(entry);

--- a/src/toc/mod.rs
+++ b/src/toc/mod.rs
@@ -8,14 +8,59 @@ pub mod entry;
 pub mod reader;
 pub mod writer;
 
+const BINARY_SEARCH_THRESHOLD: usize = 64;
+
 /// Table of contents
-pub struct Toc(pub(crate) Vec<TocEntry>);
+pub struct Toc {
+    entries: Vec<TocEntry>,
+    is_sorted_by_name: bool,
+}
+
+impl Default for Toc {
+    fn default() -> Self {
+        Self { entries: Vec::default(), is_sorted_by_name: true }
+    }
+}
 
 impl Toc {
-    /// Helper method to find a section by name.
+    pub(crate) fn with_capacity(capacity: usize) -> Self {
+        Self { entries: Vec::with_capacity(capacity), is_sorted_by_name: true }
+    }
+
+    /// Find a section by name.
     #[must_use]
     pub fn section(&self, name: &[u8]) -> Option<&TocEntry> {
-        self.iter().find(|entry| entry.name() == name)
+        if self.is_sorted_by_name && self.entries.len() > BINARY_SEARCH_THRESHOLD {
+            self.entries
+                .binary_search_by_key(&name, |e| e.name())
+                .ok()
+                .and_then(|idx| self.entries.get(idx))
+        } else {
+            self.iter().find(|entry| entry.name() == name)
+        }
+    }
+
+    /// Add a new entry to the end of the table,
+    /// tracking whether or not the table is/ remains sorted.
+    pub(crate) fn push(&mut self, entry: TocEntry) {
+        let empty: [u8; 0] = [];
+        if self.is_sorted_by_name && self.entries.last().map_or(empty.as_slice(), |e: &TocEntry| e.name()) > entry.name() {
+            self.is_sorted_by_name = false;
+        }
+        self.entries.push(entry);
+    }
+
+    /// Ensure that the table of contents is sorted by section name,
+    /// returning whether the table was already sorted.
+    ///
+    /// For larger tables, sorting may improve lookup performance.
+    pub fn sort_by_name(&mut self) -> bool {
+        if self.is_sorted_by_name {
+            return true;
+        }
+        self.entries.sort_by(|a, b| a.name().cmp(b.name()));
+        self.is_sorted_by_name = true;
+        false
     }
 }
 
@@ -23,6 +68,6 @@ impl std::ops::Deref for Toc {
     type Target = [TocEntry];
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        &self.entries
     }
 }

--- a/src/toc/reader.rs
+++ b/src/toc/reader.rs
@@ -68,14 +68,13 @@ impl TocReader {
 
         let len = reader.read_u32::<LE>()?;
 
-        let mut entries = Vec::with_capacity(len as usize);
-
+        let mut toc = Toc::with_capacity(len as usize);
         for _ in 0..len {
-            entries.push(TocEntry::read_from_file(&mut reader)?);
+            toc.push(TocEntry::read_from_file(&mut reader)?);
         }
 
         reader.checksum().check(toc_checksum)?;
 
-        Ok(Toc(entries))
+        Ok(toc)
     }
 }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -4,9 +4,9 @@
 
 use crate::{
     toc::{
-        Toc,
         entry::{SectionName, TocEntry},
         writer::TocWriter,
+        Toc,
     },
     trailer::writer::TrailerWriter,
 };

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -78,16 +78,16 @@ impl<W: Write + Seek> Writer<W> {
         Ok(())
     }
 
-    fn append_trailer(mut writer: &mut W, toc: &[TocEntry]) -> crate::Result<()> {
+    fn append_trailer(&mut self) -> crate::Result<()> {
         // Write ToC
-        let toc_pos = writer.stream_position()?;
-        let toc_checksum = TocWriter::write_into(&mut writer, toc)?;
+        let toc_pos = self.writer.stream_position()?;
+        let toc_checksum = TocWriter::write_into(&mut self.writer, self.toc.as_ref())?;
 
-        let after_toc_pos = writer.stream_position()?;
+        let after_toc_pos = self.writer.stream_position()?;
         let toc_len = after_toc_pos - toc_pos;
 
         // Write trailer
-        TrailerWriter::write_into(writer, toc_checksum, toc_pos, toc_len)
+        TrailerWriter::write_into(&mut self.writer, toc_checksum, toc_pos, toc_len)
     }
 
     /// Ensure that the table of contents is sorted by section name, returning whether the table was already sorted.
@@ -119,7 +119,7 @@ impl<W: Write + Seek> Writer<W> {
         log::trace!("Finishing archive");
 
         self.append_toc_entry()?;
-        Self::append_trailer(&mut self.writer, &self.toc)?;
+        self.append_trailer()?;
         self.writer.flush()?;
 
         Ok(self.writer)


### PR DESCRIPTION
Allow the table of contents to be sorted by name so that section lookups can use a binary search. Only switches to binary search when the table length reaches a threshold length.

Unsorted usage is unchanged.