### PR TITLE
Adapt fuzz driver to Writer changes in 984a49e

### DIFF
--- a/fuzz/sfa/Cargo.lock
+++ b/fuzz/sfa/Cargo.lock
@@ -166,7 +166,7 @@ checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "sfa"
-version = "0.0.1"
+version = "1.0.0"
 dependencies = [
  "byteorder-lite",
  "log",

--- a/fuzz/sfa/src/main.rs
+++ b/fuzz/sfa/src/main.rs
@@ -4,6 +4,7 @@ extern crate afl;
 use arbitrary::{Arbitrary, Unstructured};
 use sfa::{Reader, Writer};
 use std::collections::HashSet;
+use std::fs::File;
 use std::io::{Read, Write};
 
 fn main() {
@@ -19,7 +20,8 @@ fn main() {
         let mut seen = HashSet::new();
 
         {
-            let mut writer = Writer::new_at_path(&path).unwrap();
+            let mut file = File::create(&path).unwrap();
+            let mut writer = Writer::from_writer(&mut file);
 
             for i in 0..num_sections {
                 let mut name: String =


### PR DESCRIPTION
Tested on rustc 1.92.0 (stable) on Ubuntu 24.04.3 LTS and MacOS 26.1

```
cargo install cargo-afl --locked
sh FUZZ.sh
```