### PR TITLE
Add 'sfa' tool to inspect and manipulate SFA files.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,10 +62,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c5bcfa8749ac45dd12cb11055aeeb6b27a3895560d60d71e3c23bf979e60514"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "bitflags"
 version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
 
 [[package]]
 name = "byteorder-lite"
@@ -75,15 +107,61 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "clap"
+version = "4.5.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "env_filter"
@@ -123,6 +201,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,6 +220,25 @@ dependencies = [
  "r-efi",
  "wasi",
 ]
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -180,12 +286,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
 dependencies = [
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -201,10 +322,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
+name = "parse-size"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "487f2ccd1e17ce8c1bfab3a65c89525af41cfad4c8659021a1e9a2aacd73b89b"
+
+[[package]]
+name = "path_jail"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eafb3093d4faaeb6d6e81a5567b424035eaa960c36fc4e7b4d8f4d659abb7166"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
+name = "pretty-hex"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc83ee4a840062f368f9096d80077a9841ec117e17e7f700df81958f1451254"
 
 [[package]]
 name = "proc-macro2"
@@ -229,6 +398,18 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "regex"
+version = "1.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "regex-automata"
@@ -261,11 +442,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sfa"
 version = "1.0.0"
 dependencies = [
+ "assert_cmd",
  "byteorder-lite",
+ "clap",
+ "globset",
  "log",
+ "parse-size",
+ "path_jail",
+ "predicates",
+ "pretty-hex",
  "tempfile",
  "test-log",
  "xxhash-rust",
@@ -279,6 +496,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -303,6 +526,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.61.0",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-log"
@@ -400,6 +629,15 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,32 @@ publish = true
 name = "sfa"
 path = "src/lib.rs"
 
+[[bin]]
+name = "sfa"
+path = "src/tool.rs"
+required-features = ["tool"]
+
+[features]
+default = []
+tool = ["dep:clap", "dep:globset", "dep:parse-size", "dep:pretty-hex", "dep:path_jail"]
+
 [dependencies]
 byteorder = { package = "byteorder-lite", version = "0.1.0" }
+clap = { version = "4.5", features = ["derive"], optional = true }
+globset = { version = "0.4", optional = true }
+parse-size = { version = "1.0", optional = true }
+pretty-hex = { version = "0.4", optional = true }
 log = "0.4.21"
 xxhash-rust = { version = "0.8.15", features = ["xxh3"] }
+
+[target.'cfg(unix)'.dependencies]
+path_jail = { version = "0.3.1", features = ["secure-open"], optional = true }
+
+[target.'cfg(not(unix))'.dependencies]
+path_jail = { version = "0.3.1", optional = true }
 
 [dev-dependencies]
 test-log = "0.2.16"
 tempfile = "3.10.1"
+assert_cmd = "2.0"
+predicates = "3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ tool = ["dep:clap", "dep:globset", "dep:parse-size", "dep:pretty-hex", "dep:path
 [dependencies]
 byteorder = { package = "byteorder-lite", version = "0.1.0" }
 clap = { version = "4.5", features = ["derive"], optional = true }
-globset = { version = "0.4", optional = true }
+globset = { version = "0.4.18", optional = true }
 parse-size = { version = "1.0", optional = true }
 pretty-hex = { version = "0.4", optional = true }
 log = "0.4.21"

--- a/README.md
+++ b/README.md
@@ -94,6 +94,26 @@ Future breaking changes will result in a major version bump.
 
 All integers are little-endian encoded.
 
+## Inspecting and manipulating SFA files
+
+To create, dump and exatract SFA files on the command line, install the `sfa` cli, which is not built by default and is gated by the `tool` cargo feature flag:
+
+```sh
+cargo install sfa -F tool
+```
+
+The `sfa` binary should now be installed in `$HOME/.cargo/bin`, which you might need to add to your PATH.
+
+| Description                    | Command                             | Command (Shorthand)                      |
+|--------------------------------|-------------------------------------|------------------------------------------|
+| Create an SFA file             | `sfa create file.sfa f1.txt f2.txt` | `sfa c file.sfa f1.txt f2.txt`           |
+| Test and dump SFA file         | `sfa dump file.sfa`                 | `sfa d file.sfa` <br> `sfa t file.sfa`   |
+| Test and hexdump content       | `sfa dump --content file.sfa`       | `sfa dC file.sfa` <br> `sfa tC file.sfa` |
+| Extract sections as files      | `sfa extract file.sfa`              | `sfa x file.sfa`                         |
+| Extract with overwrite         | `sfa extract --force file.sfa`      | `sfa xf file.sfa`                        |
+
+See `sfa --help` for a detailed description.
+
 ## License
 
 All source code is licensed under MIT OR Apache-2.0.

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ The `sfa` binary should now be installed in `$HOME/.cargo/bin`, which you might 
 | Create an SFA file             | `sfa create file.sfa f1.txt f2.txt` | `sfa c file.sfa f1.txt f2.txt`           |
 | Test and dump SFA file         | `sfa dump file.sfa`                 | `sfa d file.sfa` <br> `sfa t file.sfa`   |
 | Test and hexdump content       | `sfa dump --content file.sfa`       | `sfa dC file.sfa` <br> `sfa tC file.sfa` |
+| Cat section(s) to stdout       | `sfa cat --content f1.txt f\*.sfa`  | `sfa cat file.sfa f*.txt`                |
 | Extract sections as files      | `sfa extract file.sfa`              | `sfa x file.sfa`                         |
 | Extract with overwrite         | `sfa extract --force file.sfa`      | `sfa xf file.sfa`                        |
 

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -2,7 +2,7 @@
 // This source code is licensed under both the Apache 2.0 and MIT License
 // (found in the LICENSE-* files in the repository)
 
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
 use globset::Glob;
 use path_jail;
 use pretty_hex::{HexConfig, PrettyHex};
@@ -127,14 +127,12 @@ fn main() {
     let mut args: Vec<String> = std::env::args().collect();
 
     // "args stuffing" to support tar-like command shorthands
-    // Only transform if it's a single char command or tar-like shorthand (e.g., "cf", "xf")
+    // Only transform if the verb is not a registered command
     if args.len() >= 2 {
         let arg = args[1].clone();
         if let Some(cmd @ ('d' | 't' | 'x' | 'c')) = arg.chars().next() {
-            // Only transform if it's a single character or tar-like shorthand (2-3 chars with flags)
-            // Don't transform full command names like "create", "dump", "extract"
-            if arg.len() == 1 || (arg.len() <= 3 && arg.chars().skip(1).all(|c| c.is_alphabetic()))
-            {
+            // Make sure we're not transforming actual commands
+            if Args::command().find_subcommand(arg.clone()).is_none() {
                 args.remove(1);
                 if arg.len() > 1 {
                     args.insert(1, format!("-{}", &arg[1..]));

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -1,0 +1,560 @@
+// Copyright (c) 2025-present, fjall-rs
+// This source code is licensed under both the Apache 2.0 and MIT License
+// (found in the LICENSE-* files in the repository)
+
+use clap::{Parser, Subcommand};
+use globset::Glob;
+use path_jail;
+use pretty_hex::{HexConfig, PrettyHex};
+use sfa::{Reader, Writer};
+use std::fs::File;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+
+macro_rules! die {
+    ($fmt:literal, $($arg:tt)*) => {{
+        eprintln!($fmt, $($arg)*);
+        std::process::exit(1);
+    }};
+
+    ($msg:literal) => {{
+        eprintln!($msg);
+        std::process::exit(1);
+    }};
+
+    () => {{
+        eprintln!("Program terminated unexpectedly");
+        std::process::exit(1);
+    }};
+}
+
+fn parse_block_size(s: &str) -> Result<usize, String> {
+    // Use powers-of-two for block size
+    let cfg = parse_size::Config::new().with_binary();
+    cfg.parse_size(s)
+        .map(|size| size as usize)
+        .map_err(|e| e.to_string())
+}
+
+/// Simple Flat Archive (SFA) command-line tool
+///
+/// Usage examples (using shorthands):
+///
+///     Create an SFA file:           sfa c file.sfa f1.txt f2.txt
+///     Test and dump an SFA file:    sfa t file.sfa
+///     Extract sections as files:    sfa x file.sfa
+#[derive(Parser)]
+#[command(name = "sfa")]
+#[command(arg_required_else_help = true)]
+#[command(verbatim_doc_comment)]
+struct Args {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Dump SFA file sections and metadata
+    #[command(visible_aliases = ["d", "test", "t"])]
+    #[command(arg_required_else_help = true)]
+    Dump {
+        /// Path to the SFA file
+        file: std::path::PathBuf,
+
+        /// Dump section content in hexdump format
+        #[arg(long, short = 'C')]
+        content: bool,
+
+        /// Only operate on sections matching the glob pattern
+        #[arg(long, short = 's')]
+        section: Option<String>,
+    },
+    /// Create a new SFA file from input files
+    #[command(visible_aliases = ["c"])]
+    #[command(arg_required_else_help = true)]
+    Create {
+        /// Path to the SFA file to create
+        output: std::path::PathBuf,
+
+        /// Input files to add to the archive
+        #[arg(required = true)]
+        files: Vec<std::path::PathBuf>,
+
+        /// Overwrite existing file
+        #[arg(long, short = 'f')]
+        force: bool,
+
+        /// Block size for section content import
+        #[arg(
+            short = 'b',
+            long = "block-size",
+            default_value = "64KB",
+            value_parser = parse_block_size
+        )]
+        block_size: usize,
+    },
+    /// Extract all sections from an SFA file
+    #[command(visible_aliases = ["x"])]
+    #[command(arg_required_else_help = true)]
+    Extract {
+        /// Path to the SFA file
+        file: std::path::PathBuf,
+
+        /// Overwrite existing files
+        #[arg(long, short = 'f')]
+        force: bool,
+
+        /// Block size for section content extraction
+        #[arg(
+            short = 'b',
+            long = "block-size",
+            default_value = "64KB",
+            value_parser = parse_block_size
+        )]
+        block_size: usize,
+
+        /// Only operate on sections matching the glob pattern
+        #[arg(long, short = 's')]
+        section: Option<String>,
+
+        /// The destination base path to extract to
+        #[arg(short = 'D', long = "dest", default_value = ".")]
+        dest: PathBuf,
+    },
+}
+
+fn main() {
+    let mut args: Vec<String> = std::env::args().collect();
+
+    // "args stuffing" to support tar-like command shorthands
+    // Only transform if it's a single char command or tar-like shorthand (e.g., "cf", "xf")
+    if args.len() >= 2 {
+        let arg = args[1].clone();
+        if let Some(cmd @ ('d' | 't' | 'x' | 'c')) = arg.chars().next() {
+            // Only transform if it's a single character or tar-like shorthand (2-3 chars with flags)
+            // Don't transform full command names like "create", "dump", "extract"
+            if arg.len() == 1 || (arg.len() <= 3 && arg.chars().skip(1).all(|c| c.is_alphabetic()))
+            {
+                args.remove(1);
+                if arg.len() > 1 {
+                    args.insert(1, format!("-{}", &arg[1..]));
+                }
+                args.insert(1, format!("{}", cmd));
+            }
+        }
+    }
+
+    let args = Args::parse_from(args);
+
+    match args.command {
+        Commands::Dump {
+            file,
+            content,
+            section,
+        } => {
+            dump_command(&file, content, section.as_deref());
+        }
+        Commands::Create {
+            output,
+            files,
+            force,
+            block_size,
+        } => {
+            create_command(&output, &files, force, block_size);
+        }
+        Commands::Extract {
+            file,
+            force,
+            block_size,
+            section,
+            dest,
+        } => {
+            extract_command(&file, force, section.as_deref(), block_size, &dest);
+        }
+    }
+}
+
+fn build_section_matcher(section_pattern: Option<&str>) -> Option<globset::GlobMatcher> {
+    section_pattern.and_then(|pattern| match Glob::new(pattern) {
+        Ok(glob) => Some(glob.compile_matcher()),
+        Err(e) => {
+            die!("Error parsing glob pattern: {}", e);
+        }
+    })
+}
+
+fn section_matches(entry: &sfa::TocEntry, matcher: Option<&globset::GlobMatcher>) -> bool {
+    if let Some(matcher) = matcher {
+        match std::str::from_utf8(entry.name()) {
+            Ok(name) => matcher.is_match(name),
+            Err(_) => false,
+        }
+    } else {
+        true
+    }
+}
+
+fn format_section_name(name: &[u8]) -> String {
+    if name.is_empty() {
+        return "(empty)".to_string();
+    }
+    match std::str::from_utf8(name) {
+        Ok(s) => {
+            if s.chars().all(|c| {
+                c.is_ascii()
+                    && (c.is_alphanumeric() || c.is_whitespace() || c.is_ascii_punctuation())
+            }) {
+                format!("\"{s}\"")
+            } else {
+                format!("{s}")
+            }
+        }
+        Err(_) => format!("{:?}", name),
+    }
+}
+
+fn dump_command(file: &std::path::Path, content_dump: bool, section_pattern: Option<&str>) {
+    let reader = match Reader::new(file) {
+        Ok(r) => r,
+        Err(e) => {
+            die!("Error opening SFA file: {}", e);
+        }
+    };
+
+    let toc = reader.toc();
+
+    if toc.is_empty() {
+        println!("SFA file contains no sections.");
+        return;
+    }
+
+    let matcher = build_section_matcher(section_pattern);
+
+    println!("SFA file: {}", file.display());
+    println!("Number of sections: {}\n", toc.len());
+
+    // Process matching sections as we encounter them
+    let mut total_count = 0;
+    let mut match_count = 0;
+    for (original_idx, entry) in toc.iter().enumerate() {
+        total_count += 1;
+        if !section_matches(entry, matcher.as_ref()) {
+            continue;
+        }
+
+        if match_count > 0 {
+            println!();
+        }
+        match_count += 1;
+
+        println!("Section {}:", original_idx);
+        println!("  Name: {}", format_section_name(entry.name()));
+        println!("  Position: {} (0x{:x})", entry.pos(), entry.pos());
+        println!("  Length: {} bytes (0x{:x})", entry.len(), entry.len());
+
+        if content_dump {
+            println!("  Content:");
+            println!();
+            match entry.buf_reader(file) {
+                Ok(mut reader) => {
+                    const BLOCK_SIZE: usize = 4096;
+                    let mut buffer = vec![0u8; BLOCK_SIZE];
+                    let mut offset = 0u64;
+
+                    loop {
+                        match reader.read(&mut buffer) {
+                            Ok(0) => break, // EOF
+                            Ok(n) => {
+                                let data = &buffer[..n];
+                                let cfg = HexConfig {
+                                    title: false,
+                                    width: 16,
+                                    group: 8,
+                                    display_offset: offset as usize,
+                                    ..HexConfig::default()
+                                };
+                                println!("{:?}", data.hex_conf(cfg));
+                                offset += n as u64;
+                            }
+                            Err(e) => {
+                                eprintln!("Error reading section content: {}", e);
+                                break;
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    eprintln!("Error opening section: {}", e);
+                }
+            }
+        }
+    }
+
+    if section_pattern.is_some() {
+        println!("\nDumped {match_count} of {total_count} sections.");
+    } else {
+        println!("\nDumped {total_count} sections.");
+    }
+}
+
+fn create_command(
+    output: &std::path::Path,
+    files: &[std::path::PathBuf],
+    force: bool,
+    block_size: usize,
+) {
+    // Check if the output file already exists
+    if output.exists() && !force {
+        die!(
+            "file {} already exists. Use --force to overwrite.",
+            output.display()
+        );
+    }
+
+    let mut file = match File::create(output) {
+        Ok(f) => f,
+        Err(e) => {
+            die!("Error creating SFA file: {}", e);
+        }
+    };
+
+    let mut writer = Writer::from_writer(&mut file);
+    let mut chunk = vec![0u8; block_size];
+
+    for input_file in files {
+        // Use the filename (without path) as the section name
+        let section_name = input_file
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or_else(|| {
+                die!("invalid filename for {}", input_file.display());
+            });
+
+        // Start a new section
+        if let Err(e) = writer.start(section_name) {
+            die!("Error starting section {}: {}", section_name, e);
+        }
+
+        // Open the input file for reading
+        let mut input = match File::open(input_file) {
+            Ok(f) => f,
+            Err(e) => {
+                die!("Error reading file {}: {}", input_file.display(), e);
+            }
+        };
+
+        // Stream the file content in chunks
+        loop {
+            match input.read(&mut chunk) {
+                Ok(0) => break, // EOF
+                Ok(n) => {
+                    let data = &chunk[..n];
+                    if let Err(e) = writer.write_all(data) {
+                        die!("Error writing section {}: {}", section_name, e);
+                    }
+                }
+                Err(e) => {
+                    die!("Error reading file {}: {}", input_file.display(), e);
+                }
+            }
+        }
+    }
+
+    // Finish the archive
+    if let Err(e) = writer.finish() {
+        die!("Error finishing SFA file: {}", e);
+    }
+
+    // Sync the file to disk
+    if let Err(e) = file.sync_all() {
+        die!("Error syncing SFA file: {}", e);
+    }
+
+    println!(
+        "Created SFA file: {} with {} sections",
+        output.display(),
+        files.len()
+    );
+}
+
+#[cfg(unix)]
+fn safely_open_file_or_die(
+    dest: &path_jail::Jail,
+    output_path_raw: &Path,
+    output_path_jailed: &Path,
+    force: bool,
+) -> File {
+    // On Unix, directly open file from raw filename within the dest jail
+    // to avoid TOCTOU (Time-of-Check to Time-of-Use) attacks.
+
+    match if force {
+        dest.create_or_truncate(output_path_raw)
+    } else {
+        dest.create(output_path_raw)
+    } {
+        Ok(f) => f.into_inner(),
+        Err(e) => {
+            if let path_jail::JailError::Io(io_err) = &e {
+                if io_err.kind() == std::io::ErrorKind::AlreadyExists {
+                    die!(
+                        "File {} already exists. Use --force to overwrite.",
+                        output_path_jailed.display()
+                    );
+                }
+            }
+            die!("Error opening file {}: {e}", output_path_jailed.display());
+        }
+    }
+}
+
+//#[allow(dead_code)] // Comment in if testing on Unix
+#[cfg(not(unix))] // Comment out if testing on Unix
+fn safely_open_file_or_die(
+    _dest: &path_jail::Jail,
+    _output_path_raw: &Path,
+    output_path_jailed: &Path,
+    force: bool,
+) -> File {
+    // As the path_jail crate only supports the secure-open feature on unix,
+    // we need to handle the other platforms separately. The workaround can
+    // be removed once the path_jail crate supports the secure-open feature
+    // on all platforms.
+
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true);
+
+    if force {
+        options.create(true).truncate(true);
+    } else {
+        options.create_new(true);
+    }
+
+    match options.open(output_path_jailed) {
+        Ok(f) => f,
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+            die!(
+                "File {} already exists. Use --force to overwrite.",
+                output_path_jailed.display()
+            )
+        }
+        Err(e) => {
+            die!("Error creating file {}: {e}", output_path_jailed.display());
+        }
+    }
+}
+
+fn extract_command(
+    file: &std::path::Path,
+    force: bool,
+    section_pattern: Option<&str>,
+    block_size: usize,
+    dest: &std::path::Path,
+) {
+    let dest = match path_jail::Jail::new(dest) {
+        Ok(p) => p,
+        Err(e) => {
+            die!(
+                "Error creating path jail for destination {}: {e}",
+                dest.display()
+            );
+        }
+    };
+
+    let reader = match Reader::new(file) {
+        Ok(r) => r,
+        Err(e) => {
+            die!("Error opening SFA file: {}", e);
+        }
+    };
+
+    let toc = reader.toc();
+
+    if toc.is_empty() {
+        println!("SFA file contains no sections.");
+        return;
+    }
+
+    let matcher = build_section_matcher(section_pattern);
+
+    // Process matching sections, counting as we go
+    let mut total_count = 0;
+    let mut match_count = 0;
+    let mut chunk = vec![0u8; block_size];
+
+    for entry in toc.iter() {
+        total_count += 1;
+        if !section_matches(entry, matcher.as_ref()) {
+            continue;
+        }
+
+        match_count += 1;
+
+        let section_name = match std::str::from_utf8(entry.name()) {
+            Ok(s) => s,
+            Err(_) => {
+                die!(
+                    "Error: section name contains invalid UTF-8: {:?}",
+                    entry.name()
+                );
+            }
+        };
+        let output_path_raw = Path::new(section_name);
+        let output_path_jailed = match dest.join(output_path_raw) {
+            Ok(p) => p,
+            Err(e) => {
+                die!(
+                    "Error jailing path {} to dest {}: {e}",
+                    output_path_raw.display(),
+                    dest.root().display()
+                );
+            }
+        };
+
+        let mut output_file_jailed =
+            safely_open_file_or_die(&dest, &output_path_raw, &output_path_jailed, force);
+
+        match entry.buf_reader(file) {
+            Ok(mut reader) => {
+                'eof: loop {
+                    match reader.read(&mut chunk) {
+                        Ok(0) => break 'eof, // EOF
+                        Ok(n) => {
+                            let data = &chunk[..n];
+                            if let Err(e) = output_file_jailed.write_all(data) {
+                                die!(
+                                    "Error writing to file {}: {e}",
+                                    output_path_jailed.display()
+                                );
+                            }
+                        }
+                        Err(e) => {
+                            die!(
+                                "Error reading section {}: {e}",
+                                output_path_jailed.display()
+                            );
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                die!("Error opening section {section_name}: {e}");
+            }
+        }
+
+        // Sync the file to disk
+        if let Err(e) = output_file_jailed.sync_all() {
+            die!("Error syncing file {}: {e}", output_path_jailed.display());
+        }
+
+        println!(
+            "Extracted: {section_name} to {}",
+            output_path_jailed.display()
+        );
+    }
+
+    if section_pattern.is_some() {
+        println!("\nExtracted {match_count} of {total_count} sections.");
+    } else {
+        println!("\nExtracted {total_count} sections.");
+    }
+}

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -224,7 +224,7 @@ fn dump_command(file: &std::path::Path, content_dump: bool, section_pattern: Opt
     let toc = reader.toc();
 
     if toc.is_empty() {
-        println!("SFA file contains no sections.");
+        eprintln!("SFA file contains no sections.");
         return;
     }
 
@@ -470,7 +470,7 @@ fn extract_command(
     let toc = reader.toc();
 
     if toc.is_empty() {
-        println!("SFA file contains no sections.");
+        eprintln!("SFA file contains no sections.");
         return;
     }
 

--- a/tests/tool_tests.rs
+++ b/tests/tool_tests.rs
@@ -445,7 +445,7 @@ fn test_dump_empty_archive() {
         .arg(path_to_arg(&archive))
         .assert()
         .success()
-        .stdout(predicate::str::contains("SFA file contains no sections"));
+        .stderr(predicate::str::contains("SFA file contains no sections"));
 }
 
 #[test]
@@ -798,7 +798,7 @@ fn test_extract_empty_archive() {
         .arg(path_to_arg(&archive))
         .assert()
         .success()
-        .stdout(predicate::str::contains("SFA file contains no sections"));
+        .stderr(predicate::str::contains("SFA file contains no sections"));
 }
 
 #[test]
@@ -932,7 +932,7 @@ fn test_create_with_empty_file() {
         .arg(path_to_arg(&output))
         .assert()
         .success()
-        .stdout(predicate::str::contains("SFA file contains no sections"));
+        .stderr(predicate::str::contains("SFA file contains no sections"));
 }
 
 #[test]

--- a/tests/tool_tests.rs
+++ b/tests/tool_tests.rs
@@ -244,8 +244,12 @@ fn test_cat_all_sections() {
 
     // Check raw bytes since output includes binary content from file3.dat
     let stdout = &output.get_output().stdout;
-    assert!(stdout.windows(b"Hello, world!".len()).any(|w| w == b"Hello, world!"));
-    assert!(stdout.windows(b"Test content".len()).any(|w| w == b"Test content"));
+    assert!(stdout
+        .windows(b"Hello, world!".len())
+        .any(|w| w == b"Hello, world!"));
+    assert!(stdout
+        .windows(b"Test content".len())
+        .any(|w| w == b"Test content"));
     assert!(stdout.windows(b"Line 2".len()).any(|w| w == b"Line 2"));
 }
 

--- a/tests/tool_tests.rs
+++ b/tests/tool_tests.rs
@@ -1,0 +1,1046 @@
+// Copyright (c) 2025-present, fjall-rs
+// This source code is licensed under both the Apache 2.0 and MIT License
+// (found in the LICENSE-* files in the repository)
+
+#![cfg(feature = "tool")]
+
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::*;
+use sfa::Writer;
+use std::fs;
+use std::io::Write;
+use tempfile::TempDir;
+
+fn path_to_arg(path: &std::path::Path) -> String {
+    path.to_string_lossy().to_string()
+}
+
+fn create_test_files(
+    dir: &TempDir,
+) -> (std::path::PathBuf, std::path::PathBuf, std::path::PathBuf) {
+    let file1 = dir.path().join("file1.txt");
+    let file2 = dir.path().join("file2.txt");
+    let file3 = dir.path().join("file3.dat");
+
+    fs::write(&file1, b"Hello, world!\n").unwrap();
+    fs::write(&file2, b"Test content\nLine 2\n").unwrap();
+    fs::write(&file3, b"\x00\x01\x02\x03\xff\xfe\xfd").unwrap();
+
+    (file1, file2, file3)
+}
+
+// ============================================================================
+// CREATE COMMAND TESTS
+// ============================================================================
+
+#[test]
+fn test_create_basic() {
+    let dir = tempfile::tempdir().unwrap();
+    let (file1, file2, _) = create_test_files(&dir);
+    let output = dir.path().join("archive.sfa");
+
+    cargo_bin_cmd!()
+        .arg("create")
+        .arg(path_to_arg(&output))
+        .arg(path_to_arg(&file1))
+        .arg(path_to_arg(&file2))
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Created SFA file"))
+        .stdout(predicate::str::contains("with 2 sections"));
+
+    assert!(output.exists());
+}
+
+#[test]
+fn test_create_alias_c() {
+    let dir = tempfile::tempdir().unwrap();
+    let (file1, file2, _) = create_test_files(&dir);
+    let output = dir.path().join("archive.sfa");
+
+    cargo_bin_cmd!()
+        .arg("c")
+        .arg(path_to_arg(&output))
+        .arg(path_to_arg(&file1))
+        .arg(path_to_arg(&file2))
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Created SFA file"))
+        .stdout(predicate::str::contains("with 2 sections"));
+
+    assert!(output.exists());
+}
+
+#[test]
+fn test_create_single_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let (file1, _, _) = create_test_files(&dir);
+    let output = dir.path().join("archive.sfa");
+
+    cargo_bin_cmd!()
+        .arg("create")
+        .arg(path_to_arg(&output))
+        .arg(path_to_arg(&file1))
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("with 1 sections"));
+
+    assert!(output.exists());
+}
+
+#[test]
+fn test_create_multiple_files() {
+    let dir = tempfile::tempdir().unwrap();
+    let (file1, file2, file3) = create_test_files(&dir);
+    let output = dir.path().join("archive.sfa");
+
+    cargo_bin_cmd!()
+        .arg("create")
+        .arg(path_to_arg(&output))
+        .arg(path_to_arg(&file1))
+        .arg(path_to_arg(&file2))
+        .arg(path_to_arg(&file3))
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("with 3 sections"));
+
+    assert!(output.exists());
+}
+
+#[test]
+fn test_create_force_overwrite() {
+    let dir = tempfile::tempdir().unwrap();
+    let (file1, _, _) = create_test_files(&dir);
+    let output = dir.path().join("archive.sfa");
+
+    // Create initial archive
+    cargo_bin_cmd!()
+        .arg("create")
+        .arg(path_to_arg(&output))
+        .arg(path_to_arg(&file1))
+        .assert()
+        .success();
+
+    // Overwrite with force flag
+    cargo_bin_cmd!()
+        .arg("create")
+        .arg("--force")
+        .arg(path_to_arg(&output))
+        .arg(&file1)
+        .assert()
+        .success();
+
+    assert!(output.exists());
+}
+
+#[test]
+fn test_create_force_short_flag() {
+    let dir = tempfile::tempdir().unwrap();
+    let (file1, _, _) = create_test_files(&dir);
+    let output = dir.path().join("archive.sfa");
+
+    // Create initial archive
+    cargo_bin_cmd!()
+        .arg("create")
+        .arg(path_to_arg(&output))
+        .arg(path_to_arg(&file1))
+        .assert()
+        .success();
+
+    // Overwrite with short force flag
+    cargo_bin_cmd!()
+        .arg("create")
+        .arg("-f")
+        .arg(path_to_arg(&output))
+        .arg(&file1)
+        .assert()
+        .success();
+}
+
+#[test]
+fn test_create_without_force_fails_if_exists() {
+    let dir = tempfile::tempdir().unwrap();
+    let (file1, _, _) = create_test_files(&dir);
+    let output = dir.path().join("archive.sfa");
+
+    // Create initial archive
+    cargo_bin_cmd!()
+        .arg("create")
+        .arg(path_to_arg(&output))
+        .arg(path_to_arg(&file1))
+        .assert()
+        .success();
+
+    // Try to create again without force - should fail
+    cargo_bin_cmd!()
+        .arg("create")
+        .arg(path_to_arg(&output))
+        .arg(path_to_arg(&file1))
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("already exists"))
+        .stderr(predicate::str::contains("Use --force to overwrite"));
+}
+
+#[test]
+fn test_create_missing_input_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let output = dir.path().join("archive.sfa");
+    let missing_file = dir.path().join("nonexistent.txt");
+
+    cargo_bin_cmd!()
+        .arg("create")
+        .arg(path_to_arg(&output))
+        .arg(path_to_arg(&missing_file))
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Error reading file"));
+}
+
+#[test]
+fn test_create_no_input_files() {
+    let dir = tempfile::tempdir().unwrap();
+    let output = dir.path().join("archive.sfa");
+
+    cargo_bin_cmd!()
+        .arg("create")
+        .arg(path_to_arg(&output))
+        .assert()
+        .failure();
+}
+
+#[test]
+fn test_create_binary_content() {
+    let dir = tempfile::tempdir().unwrap();
+    let binary_file = dir.path().join("binary.bin");
+    fs::write(&binary_file, b"\x00\x01\x02\x03\xff\xfe\xfd\xfc").unwrap();
+    let output = dir.path().join("archive.sfa");
+
+    cargo_bin_cmd!()
+        .arg("create")
+        .arg(path_to_arg(&output))
+        .arg(path_to_arg(&binary_file))
+        .assert()
+        .success();
+
+    assert!(output.exists());
+}
+
+// ============================================================================
+// DUMP COMMAND TESTS
+// ============================================================================
+
+fn create_test_archive(dir: &TempDir) -> std::path::PathBuf {
+    let (file1, file2, file3) = create_test_files(dir);
+    let output = dir.path().join("archive.sfa");
+
+    cargo_bin_cmd!()
+        .arg("create")
+        .arg(path_to_arg(&output))
+        .arg(path_to_arg(&file1))
+        .arg(path_to_arg(&file2))
+        .arg(path_to_arg(&file3))
+        .assert()
+        .success();
+
+    output
+}
+
+fn setup_extract_test(dir: &TempDir, _archive: &std::path::Path) {
+    // Remove original files so extract can create them
+    fs::remove_file(dir.path().join("file1.txt")).ok();
+    fs::remove_file(dir.path().join("file2.txt")).ok();
+    fs::remove_file(dir.path().join("file3.dat")).ok();
+}
+
+#[test]
+fn test_dump_basic() {
+    let dir = tempfile::tempdir().unwrap();
+    let archive = create_test_archive(&dir);
+
+    cargo_bin_cmd!()
+        .arg("dump")
+        .arg(path_to_arg(&archive))
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("SFA file:"))
+        .stdout(predicate::str::contains("Number of sections: 3"))
+        .stdout(predicate::str::contains("Section 0:"))
+        .stdout(predicate::str::contains("Section 1:"))
+        .stdout(predicate::str::contains("Section 2:"))
+        .stdout(predicate::str::contains("file1.txt"))
+        .stdout(predicate::str::contains("file2.txt"))
+        .stdout(predicate::str::contains("file3.dat"))
+        .stdout(predicate::str::contains("Dumped 3 sections"));
+}
+
+#[test]
+fn test_dump_alias_d() {
+    let dir = tempfile::tempdir().unwrap();
+    let archive = create_test_archive(&dir);
+
+    cargo_bin_cmd!()
+        .arg("d")
+        .arg(path_to_arg(&archive))
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Number of sections: 3"));
+}
+
+#[test]
+fn test_dump_alias_t() {
+    let dir = tempfile::tempdir().unwrap();
+    let archive = create_test_archive(&dir);
+
+    cargo_bin_cmd!()
+        .arg("t")
+        .arg(path_to_arg(&archive))
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Number of sections: 3"));
+}
+
+#[test]
+fn test_dump_alias_test() {
+    let dir = tempfile::tempdir().unwrap();
+    let archive = create_test_archive(&dir);
+
+    cargo_bin_cmd!()
+        .arg("test")
+        .arg(path_to_arg(&archive))
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Number of sections: 3"));
+}
+
+#[test]
+fn test_dump_with_content() {
+    let dir = tempfile::tempdir().unwrap();
+    let archive = create_test_archive(&dir);
+
+    cargo_bin_cmd!()
+        .arg("dump")
+        .arg("--content")
+        .arg(path_to_arg(&archive))
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Content:"))
+        .stdout(predicate::str::contains("Hello, world!"));
+}
+
+#[test]
+fn test_dump_with_content_short_flag() {
+    let dir = tempfile::tempdir().unwrap();
+    let archive = create_test_archive(&dir);
+
+    cargo_bin_cmd!()
+        .arg("dump")
+        .arg("-C")
+        .arg(path_to_arg(&archive))
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Content:"));
+}
+
+#[test]
+fn test_dump_with_section_pattern() {
+    let dir = tempfile::tempdir().unwrap();
+    let archive = create_test_archive(&dir);
+
+    cargo_bin_cmd!()
+        .arg("dump")
+        .arg("--section")
+        .arg("file1.txt")
+        .arg(path_to_arg(&archive))
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Section 0:"))
+        .stdout(predicate::str::contains("file1.txt"))
+        .stdout(predicate::str::contains("Dumped 1 of 3 sections"));
+}
+
+#[test]
+fn test_dump_with_section_pattern_short_flag() {
+    let dir = tempfile::tempdir().unwrap();
+    let archive = create_test_archive(&dir);
+
+    cargo_bin_cmd!()
+        .arg("dump")
+        .arg("-s")
+        .arg("file2.txt")
+        .arg(path_to_arg(&archive))
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Dumped 1 of 3 sections"));
+}
+
+#[test]
+fn test_dump_with_section_glob_pattern() {
+    let dir = tempfile::tempdir().unwrap();
+    let archive = create_test_archive(&dir);
+
+    cargo_bin_cmd!()
+        .arg("dump")
+        .arg("--section")
+        .arg("file*.txt")
+        .arg(path_to_arg(&archive))
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Dumped 2 of 3 sections"));
+}
+
+#[test]
+fn test_dump_with_section_pattern_no_match() {
+    let dir = tempfile::tempdir().unwrap();
+    let archive = create_test_archive(&dir);
+
+    cargo_bin_cmd!()
+        .arg("dump")
+        .arg("--section")
+        .arg("nonexistent*")
+        .arg(path_to_arg(&archive))
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Dumped 0 of 3 sections"));
+}
+
+#[test]
+fn test_dump_with_content_and_section() {
+    let dir = tempfile::tempdir().unwrap();
+    let archive = create_test_archive(&dir);
+
+    cargo_bin_cmd!()
+        .arg("dump")
+        .arg("--content")
+        .arg("--section")
+        .arg("file1.txt")
+        .arg(path_to_arg(&archive))
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Content:"))
+        .stdout(predicate::str::contains("Hello, world!"))
+        .stdout(predicate::str::contains("Dumped 1 of 3 sections"));
+}
+
+#[test]
+fn test_dump_empty_archive() {
+    let dir = tempfile::tempdir().unwrap();
+    let archive = dir.path().join("empty.sfa");
+
+    // Create an empty archive (this would require using the library directly,
+    // but for now we'll test with a non-existent file which should error)
+    // Actually, let's create a minimal valid archive
+    let file1 = dir.path().join("file1.txt");
+    fs::write(&file1, b"").unwrap();
+
+    cargo_bin_cmd!()
+        .arg("create")
+        .arg(path_to_arg(&archive))
+        .arg(&file1)
+        .assert()
+        .success();
+
+    cargo_bin_cmd!()
+        .arg("dump")
+        .arg(path_to_arg(&archive))
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("SFA file contains no sections"));
+}
+
+#[test]
+fn test_dump_invalid_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let invalid_file = dir.path().join("invalid.sfa");
+    fs::write(&invalid_file, b"not a valid sfa file").unwrap();
+
+    cargo_bin_cmd!()
+        .arg("dump")
+        .arg(path_to_arg(&invalid_file))
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Error opening SFA file"));
+}
+
+#[test]
+fn test_dump_nonexistent_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let nonexistent = dir.path().join("nonexistent.sfa");
+
+    cargo_bin_cmd!()
+        .arg("dump")
+        .arg(path_to_arg(&nonexistent))
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Error opening SFA file"));
+}
+
+#[test]
+fn test_dump_invalid_glob_pattern() {
+    let dir = tempfile::tempdir().unwrap();
+    let archive = create_test_archive(&dir);
+
+    cargo_bin_cmd!()
+        .arg("dump")
+        .arg("--section")
+        .arg("[invalid")
+        .arg(path_to_arg(&archive))
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Error parsing glob pattern"));
+}
+
+// ============================================================================
+// EXTRACT COMMAND TESTS
+// ============================================================================
+
+#[test]
+fn test_extract_basic() {
+    let dir = tempfile::tempdir().unwrap();
+    let archive = create_test_archive(&dir);
+
+    setup_extract_test(&dir, &archive);
+
+    cargo_bin_cmd!()
+        .current_dir(dir.path())
+        .arg("extract")
+        .arg(path_to_arg(&archive))
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Extracted: file1.txt"))
+        .stdout(predicate::str::contains("Extracted: file2.txt"))
+        .stdout(predicate::str::contains("Extracted: file3.dat"))
+        .stdout(predicate::str::contains("Extracted 3 sections"));
+
+    // Verify extracted files
+    let file1_content = fs::read(dir.path().join("file1.txt")).unwrap();
+    assert_eq!(file1_content, b"Hello, world!\n");
+
+    let file2_content = fs::read(dir.path().join("file2.txt")).unwrap();
+    assert_eq!(file2_content, b"Test content\nLine 2\n");
+
+    let file3_content = fs::read(dir.path().join("file3.dat")).unwrap();
+    assert_eq!(file3_content, b"\x00\x01\x02\x03\xff\xfe\xfd");
+}
+
+#[test]
+fn test_extract_alias_x() {
+    let dir = tempfile::tempdir().unwrap();
+    let archive = create_test_archive(&dir);
+    setup_extract_test(&dir, &archive);
+
+    cargo_bin_cmd!()
+        .current_dir(dir.path())
+        .arg("x")
+        .arg(path_to_arg(&archive))
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Extracted 3 sections"));
+
+    assert!(dir.path().join("file1.txt").exists());
+}
+
+#[test]
+fn test_extract_single_section() {
+    let dir = tempfile::tempdir().unwrap();
+    let archive = create_test_archive(&dir);
+    setup_extract_test(&dir, &archive);
+
+    cargo_bin_cmd!()
+        .current_dir(dir.path())
+        .arg("extract")
+        .arg("--section")
+        .arg("file1.txt")
+        .arg(path_to_arg(&archive))
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Extracted: file1.txt"))
+        .stdout(predicate::str::contains("Extracted 1 of 3 sections"));
+
+    assert!(dir.path().join("file1.txt").exists());
+    assert!(!dir.path().join("file2.txt").exists());
+    assert!(!dir.path().join("file3.dat").exists());
+}
+
+#[test]
+fn test_extract_section_short_flag() {
+    let dir = tempfile::tempdir().unwrap();
+    let archive = create_test_archive(&dir);
+    setup_extract_test(&dir, &archive);
+
+    cargo_bin_cmd!()
+        .current_dir(dir.path())
+        .arg("extract")
+        .arg("-s")
+        .arg("file2.txt")
+        .arg(path_to_arg(&archive))
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Extracted 1 of 3 sections"));
+
+    assert!(dir.path().join("file2.txt").exists());
+}
+
+#[test]
+fn test_extract_section_glob_pattern() {
+    let dir = tempfile::tempdir().unwrap();
+    let archive = create_test_archive(&dir);
+    setup_extract_test(&dir, &archive);
+
+    cargo_bin_cmd!()
+        .current_dir(dir.path())
+        .arg("extract")
+        .arg("--section")
+        .arg("file*.txt")
+        .arg(path_to_arg(&archive))
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Extracted 2 of 3 sections"));
+
+    assert!(dir.path().join("file1.txt").exists());
+    assert!(dir.path().join("file2.txt").exists());
+    assert!(!dir.path().join("file3.dat").exists());
+}
+
+#[test]
+fn test_extract_with_force() {
+    let dir = tempfile::tempdir().unwrap();
+    let archive = create_test_archive(&dir);
+    setup_extract_test(&dir, &archive);
+
+    // Extract first time
+    cargo_bin_cmd!()
+        .current_dir(dir.path())
+        .arg("extract")
+        .arg(path_to_arg(&archive))
+        .assert()
+        .success();
+
+    // Extract again with force
+    cargo_bin_cmd!()
+        .current_dir(dir.path())
+        .arg("extract")
+        .arg("--force")
+        .arg(path_to_arg(&archive))
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Extracted 3 sections"));
+}
+
+#[test]
+fn test_extract_with_force_short_flag() {
+    let dir = tempfile::tempdir().unwrap();
+    let archive = create_test_archive(&dir);
+    setup_extract_test(&dir, &archive);
+
+    // Extract first time
+    cargo_bin_cmd!()
+        .current_dir(dir.path())
+        .arg("extract")
+        .arg(path_to_arg(&archive))
+        .assert()
+        .success();
+
+    // Extract again with short force flag
+    cargo_bin_cmd!()
+        .current_dir(dir.path())
+        .arg("extract")
+        .arg("-f")
+        .arg(path_to_arg(&archive))
+        .assert()
+        .success();
+}
+
+#[test]
+fn test_extract_without_force_fails_if_exists() {
+    let dir = tempfile::tempdir().unwrap();
+    let archive = create_test_archive(&dir);
+    setup_extract_test(&dir, &archive);
+
+    // Extract first time
+    cargo_bin_cmd!()
+        .current_dir(dir.path())
+        .arg("extract")
+        .arg(path_to_arg(&archive))
+        .assert()
+        .success();
+
+    // Try to extract again without force - should fail
+    cargo_bin_cmd!()
+        .current_dir(dir.path())
+        .arg("extract")
+        .arg(path_to_arg(&archive))
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("already exists"))
+        .stderr(predicate::str::contains("Use --force to overwrite"));
+}
+
+#[test]
+fn test_extract_with_block_size() {
+    let dir = tempfile::tempdir().unwrap();
+    let archive = create_test_archive(&dir);
+    setup_extract_test(&dir, &archive);
+    cargo_bin_cmd!()
+        .current_dir(dir.path())
+        .arg("extract")
+        .arg("--block-size")
+        .arg("32KB")
+        .arg(path_to_arg(&archive))
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Extracted 3 sections"));
+
+    assert!(dir.path().join("file1.txt").exists());
+}
+
+#[test]
+fn test_extract_with_block_size_short_flag() {
+    let dir = tempfile::tempdir().unwrap();
+    let archive = create_test_archive(&dir);
+    setup_extract_test(&dir, &archive);
+    cargo_bin_cmd!()
+        .current_dir(dir.path())
+        .arg("extract")
+        .arg("-b")
+        .arg("16KB")
+        .arg(path_to_arg(&archive))
+        .assert()
+        .success();
+
+    assert!(dir.path().join("file1.txt").exists());
+}
+
+#[test]
+fn test_extract_with_different_block_sizes() {
+    for block_size in ["4B", "1KB", "4KB", "64KB", "1MB"] {
+        let test_dir = tempfile::tempdir().unwrap();
+        let test_archive = create_test_archive(&test_dir);
+        setup_extract_test(&test_dir, &test_archive);
+
+        cargo_bin_cmd!()
+            .current_dir(test_dir.path())
+            .arg("extract")
+            .arg("--block-size")
+            .arg(block_size)
+            .arg(path_to_arg(&test_archive))
+            .assert()
+            .success();
+
+        let file1_content = fs::read(test_dir.path().join("file1.txt")).unwrap();
+        assert_eq!(file1_content, b"Hello, world!\n");
+    }
+}
+
+#[test]
+fn test_extract_with_all_flags() {
+    let dir = tempfile::tempdir().unwrap();
+    let archive = create_test_archive(&dir);
+    setup_extract_test(&dir, &archive);
+
+    cargo_bin_cmd!()
+        .current_dir(dir.path())
+        .arg("extract")
+        .arg("--force")
+        .arg("--block-size")
+        .arg("32KB")
+        .arg("--section")
+        .arg("file1.txt")
+        .arg(path_to_arg(&archive))
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Extracted 1 of 3 sections"));
+}
+
+#[test]
+fn test_extract_nonexistent_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let nonexistent = dir.path().join("nonexistent.sfa");
+
+    cargo_bin_cmd!()
+        .arg("extract")
+        .arg(path_to_arg(&nonexistent))
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Error opening SFA file"));
+}
+
+#[test]
+fn test_extract_invalid_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let invalid_file = dir.path().join("invalid.sfa");
+    fs::write(&invalid_file, b"not a valid sfa file").unwrap();
+
+    cargo_bin_cmd!()
+        .arg("extract")
+        .arg(path_to_arg(&invalid_file))
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Error opening SFA file"));
+}
+
+#[test]
+fn test_extract_empty_archive() {
+    let dir = tempfile::tempdir().unwrap();
+    let archive = dir.path().join("empty.sfa");
+    let empty_file = dir.path().join("empty.txt");
+    fs::write(&empty_file, b"").unwrap();
+
+    cargo_bin_cmd!()
+        .arg("create")
+        .arg(path_to_arg(&archive))
+        .arg(path_to_arg(&empty_file))
+        .assert()
+        .success();
+
+    cargo_bin_cmd!()
+        .arg("extract")
+        .arg(path_to_arg(&archive))
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("SFA file contains no sections"));
+}
+
+#[test]
+fn test_extract_invalid_glob_pattern() {
+    let dir = tempfile::tempdir().unwrap();
+    let archive = create_test_archive(&dir);
+
+    cargo_bin_cmd!()
+        .arg("extract")
+        .arg("--section")
+        .arg("[invalid")
+        .arg(path_to_arg(&archive))
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Error parsing glob pattern"));
+}
+
+#[test]
+fn test_extract_section_pattern_no_match() {
+    let dir = tempfile::tempdir().unwrap();
+    let archive = create_test_archive(&dir);
+
+    cargo_bin_cmd!()
+        .arg("extract")
+        .arg("--section")
+        .arg("nonexistent*")
+        .arg(path_to_arg(&archive))
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Extracted 0 of 3 sections"));
+}
+
+// ============================================================================
+// ROUND-TRIP TESTS
+// ============================================================================
+
+#[test]
+fn test_create_and_extract_round_trip() {
+    let dir = tempfile::tempdir().unwrap();
+    let (file1, file2, file3) = create_test_files(&dir);
+    let archive = dir.path().join("archive.sfa");
+
+    // Create archive
+    cargo_bin_cmd!()
+        .arg("create")
+        .arg(path_to_arg(&archive))
+        .arg(&file1)
+        .arg(path_to_arg(&file2))
+        .arg(path_to_arg(&file3))
+        .assert()
+        .success();
+
+    // Extract to different location
+    let extract_dir = tempfile::tempdir().unwrap();
+
+    cargo_bin_cmd!()
+        .current_dir(extract_dir.path())
+        .arg("extract")
+        .arg(path_to_arg(&archive))
+        .assert()
+        .success();
+
+    // Verify contents
+    let extracted1 = fs::read(extract_dir.path().join("file1.txt")).unwrap();
+    let extracted2 = fs::read(extract_dir.path().join("file2.txt")).unwrap();
+    let extracted3 = fs::read(extract_dir.path().join("file3.dat")).unwrap();
+
+    assert_eq!(extracted1, fs::read(&file1).unwrap());
+    assert_eq!(extracted2, fs::read(&file2).unwrap());
+    assert_eq!(extracted3, fs::read(&file3).unwrap());
+}
+
+#[test]
+fn test_create_dump_extract_workflow() {
+    let dir = tempfile::tempdir().unwrap();
+    let (file1, file2, _) = create_test_files(&dir);
+    let archive = dir.path().join("archive.sfa");
+
+    // Create
+    cargo_bin_cmd!()
+        .arg("create")
+        .arg(path_to_arg(&archive))
+        .arg(&file1)
+        .arg(path_to_arg(&file2))
+        .assert()
+        .success();
+
+    // Dump to verify
+    cargo_bin_cmd!()
+        .arg("dump")
+        .arg(path_to_arg(&archive))
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Number of sections: 2"));
+
+    // Extract
+    let extract_dir = tempfile::tempdir().unwrap();
+
+    cargo_bin_cmd!()
+        .current_dir(extract_dir.path())
+        .arg("extract")
+        .arg(path_to_arg(&archive))
+        .assert()
+        .success();
+
+    assert!(extract_dir.path().join("file1.txt").exists());
+    assert!(extract_dir.path().join("file2.txt").exists());
+}
+
+// ============================================================================
+// EDGE CASES AND ERROR HANDLING
+// ============================================================================
+
+#[test]
+fn test_create_with_empty_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let empty_file = dir.path().join("empty.txt");
+    fs::write(&empty_file, b"").unwrap();
+    let output = dir.path().join("archive.sfa");
+
+    cargo_bin_cmd!()
+        .arg("create")
+        .arg(path_to_arg(&output))
+        .arg(path_to_arg(&empty_file))
+        .assert()
+        .success();
+
+    // Verify we can dump it (empty sections are not stored)
+    cargo_bin_cmd!()
+        .arg("dump")
+        .arg(path_to_arg(&output))
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("SFA file contains no sections"));
+}
+
+#[test]
+fn test_create_with_large_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let large_file = dir.path().join("large.txt");
+    let content = vec![b'A'; 100000]; // 100KB
+    fs::write(&large_file, &content).unwrap();
+    let output = dir.path().join("archive.sfa");
+
+    cargo_bin_cmd!()
+        .arg("create")
+        .arg(path_to_arg(&output))
+        .arg(path_to_arg(&large_file))
+        .assert()
+        .success();
+
+    // Remove original file
+    fs::remove_file(&large_file).ok();
+
+    // Extract and verify
+    cargo_bin_cmd!()
+        .current_dir(dir.path())
+        .arg("extract")
+        .arg(path_to_arg(&output))
+        .assert()
+        .success();
+
+    let extracted = fs::read(dir.path().join("large.txt")).unwrap();
+    assert_eq!(extracted.len(), 100000);
+    assert_eq!(extracted, content);
+}
+
+#[test]
+fn test_extract_with_special_characters_in_filename() {
+    let dir = tempfile::tempdir().unwrap();
+    let special_file = dir.path().join("file with spaces.txt");
+    fs::write(&special_file, b"content with spaces").unwrap();
+    let output = dir.path().join("archive.sfa");
+
+    cargo_bin_cmd!()
+        .arg("create")
+        .arg(path_to_arg(&output))
+        .arg(path_to_arg(&special_file))
+        .assert()
+        .success();
+
+    // Remove original file
+    fs::remove_file(&special_file).ok();
+
+    cargo_bin_cmd!()
+        .current_dir(dir.path())
+        .arg("extract")
+        .arg(path_to_arg(&output))
+        .assert()
+        .success();
+
+    let extracted = fs::read(dir.path().join("file with spaces.txt")).unwrap();
+    assert_eq!(extracted, b"content with spaces");
+}
+
+#[test]
+fn test_no_arguments_shows_help() {
+    cargo_bin_cmd!()
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Usage:"));
+}
+
+#[test]
+fn test_invalid_command() {
+    cargo_bin_cmd!().arg("invalid").assert().failure();
+}
+
+#[test]
+fn test_command_without_required_args() {
+    cargo_bin_cmd!().arg("create").assert().failure();
+
+    cargo_bin_cmd!().arg("dump").assert().failure();
+
+    cargo_bin_cmd!().arg("extract").assert().failure();
+}
+
+#[test]
+fn test_extract_path_traversal_attack() {
+    let dir = tempfile::tempdir().unwrap();
+    let archive = dir.path().join("malicious.sfa");
+
+    // Manually create an SFA file with a path traversal attack section name
+    let mut file = std::fs::File::create(&archive).unwrap();
+    let mut writer = Writer::from_writer(&mut file);
+    writer.start("../../etc/shadow.attack.test").unwrap();
+    writer.write_all(b"malicious content").unwrap();
+    writer.finish().unwrap();
+    file.sync_all().unwrap();
+    drop(file);
+
+    // Try to extract the archive - it should refuse to create the file
+    // due to path traversal protection
+    cargo_bin_cmd!()
+        .current_dir(dir.path())
+        .arg("extract")
+        .arg(path_to_arg(&archive))
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Error jailing path"));
+
+    // Verify that the malicious file was not created in the extraction directory
+    // (path_jail should prevent any file creation outside the jail)
+    assert!(!dir.path().join("shadow.attack.test").exists());
+}


### PR DESCRIPTION
Implement command-line tool for SFA file manipulation with create, dump, and extract functionalities. Update README with usage instructions and add tests for tool commands.

Note: The `sfa` tool is gated via the 'tool' feature to not pollute the dependencies of the crate's [lib] target.

The tool can be built, tested and installed with the following commands:

```sh
cargo build -F tool
cargo build --release -F tool
cargo test -F tool --test tool_tests
cargo install --path . -F tool
```